### PR TITLE
Update Action.php

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -53,12 +53,12 @@ class ShortLinks_Action extends Typecho_Widget implements Widget_Interface_Do
         $target = $this->request->url;
         $id = $this->request->id;
         if (trim($target) == "" || $target == "http://") {
-            Typecho_Response::throwJson('error');
+            $this->response->throwJson('error');
         } else {
             if ($id) {
                 $this->db->query($this->db->update('table.shortlinks')->rows(array('target' => $target))
                         ->where('id = ?', $id));
-                Typecho_Response::throwJson('success');
+                $this->response->throwJson('success');
             }
         }
     }
@@ -163,7 +163,7 @@ class ShortLinks_Action extends Typecho_Widget implements Widget_Interface_Do
         $link = $this->request->link;
         Helper::removeRoute('go');
         Helper::addRoute('go', $link, 'ShortLinks_Action', 'shortlink');
-        Typecho_Response::throwJson('success');
+        $this->response->throwJson('success');
     }
 
     public function action()


### PR DESCRIPTION
根据https://github.com/typecho-fans/plugins/blob/master/GoLinks/Action.php 修改，似乎是新版typecho更换了接口。
不改的话在短链接管理里编辑和重设自定义链接的时候会报  Using $this when not in object context