### PR TITLE
fix: 修复短链时链接内包含特殊符号报404问题

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -58,6 +58,7 @@ class ShortLinks_Action extends Typecho_Widget implements Widget_Interface_Do
     public function edit()
     {
         $target = $this->request->url;
+        $target = base64_decode($target); // base64解码url
         $id = $this->request->id;
         if (trim($target) == "" || $target == "http://") {
             $this->response->throwJson('error');

--- a/panel.php
+++ b/panel.php
@@ -208,7 +208,7 @@ include 'footer.php';
             $('#u-' + id).click(function () {
                 $.ajax({
                     url: '<?php $options->index('/action/shortlinks?edit'); ?>',
-                    data: 'id=' + id + '&url=' + $('#t-' + id).val(),
+                    data: 'id=' + id + '&url=' + window.btoa($('#t-' + id).val()),// base64编码url
                     dataType: "json",
                     success: function (data) {
                         if (data === 'success') {


### PR DESCRIPTION
使用base64对action的url进行编码解码